### PR TITLE
Fix bug with encoding zero length arrays

### DIFF
--- a/Sources/SwiftMsgPack/Encoder.swift
+++ b/Sources/SwiftMsgPack/Encoder.swift
@@ -137,10 +137,11 @@ public extension Data {
 		else if let value_bool = obj as? Bool {
 			try self.pack(boolean: value_bool)
 		}
-        // DATA (as [UInt8])
-        else if let value_data = obj as? [UInt8] {
-            try self.pack(bytes: value_data)
-        }
+		// DATA (as [UInt8])
+		else if type(of: obj) == [UInt8].self {
+				let value_data = obj as! [UInt8]
+				try self.pack(bytes: value_data)
+		}
 		// ARRAY
 		else if let value_array = obj as? [Any?] {
 			try self.pack(array: value_array)


### PR DESCRIPTION
Currently, zero-length arrays always get converted into binary data, regardless of what type of array they are. This should fix that.

For example, consider:
```
  2> let x: [String] = []
x: [String] = 0 values
  3> let y = x as? [UInt8]
y: [UInt8]? = 0 values
```

Because of this, this cast: https://github.com/kirilltitov/SwiftMsgPack/blob/master/Sources/SwiftMsgPack/Encoder.swift#L141 always succeeds when it is a zero length array, and zero length arrays always get encoded as binary data, even when they should not be.